### PR TITLE
Feature/tory 193 ai recipe summary youtube comment briefing api

### DIFF
--- a/app/briefing/client.py
+++ b/app/briefing/client.py
@@ -1,0 +1,108 @@
+import logging
+from typing import List, Optional, Tuple
+
+import requests
+
+
+class BriefingClient:
+    def __init__(self, api_key: str, timeout: float = 20.0):
+        self.logger = logging.getLogger(__name__)
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def fetch_page(
+        self,
+        video_id: str,
+        order: str,
+        page_token: Optional[str],
+        remaining: int,
+    ) -> Tuple[List[dict], Optional[str]]:
+        """
+        YouTube Data API에서 댓글 페이지를 가져옴.
+        """
+        base_url = "https://www.googleapis.com/youtube/v3/commentThreads"
+        params = {
+            "part": "snippet",
+            "videoId": video_id,
+            "key": self.api_key,
+            "order": order,
+            "maxResults": min(100, max(1, remaining)),
+        }
+        if page_token:
+            params["pageToken"] = page_token
+
+        resp = requests.get(base_url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("items", []), data.get("nextPageToken")
+
+    def extract_comments(
+        self,
+        video_id: str,
+        order: str,
+        max_each: int,
+        seen_ids: set,
+    ) -> List[str]:
+        """
+        주어진 order(relevance/time)로 댓글을 수집.
+        - seen_ids 에 이미 있는 댓글 ID는 건너뜀
+        - 최대 max_each 개수까지 수집
+        """
+        comments: List[str] = []
+        ids = set()
+        token = None
+
+        while len(ids) < max_each:
+            try:
+                items, token = self.fetch_page(video_id, order, token, max_each - len(ids))
+            except Exception as e:
+                self.logger.exception(f"{order} 댓글 페이지 조회 중 오류: {e}")
+                break
+
+            if not items:
+                break
+
+            for it in items:
+                try:
+                    top = it["snippet"]["topLevelComment"]
+                    cid = top["id"]
+                    text = top["snippet"]["textDisplay"]
+                except KeyError:
+                    continue
+
+                if cid in seen_ids:
+                    continue
+
+                seen_ids.add(cid)
+                ids.add(cid)
+                comments.append(text)
+
+                if len(ids) >= max_each:
+                    break
+
+            if not token:
+                break
+
+        return comments
+
+    def get_video_comments(self, video_id: str, max_each: int = 50) -> List[str]:
+        """
+        유튜브 댓글을 인기순/최신순 각각 최대 max_each 개수 가져와 합친 리스트 반환.
+        중복은 제거되며, 인기순 우선.
+        """
+        try:
+            seen_ids = set()
+
+            # 인기순 수집
+            popular = self.extract_comments(video_id, "relevance", max_each, seen_ids)
+
+            # 최신순 수집 (인기순과 중복 제거)
+            recent = self.extract_comments(video_id, "time", max_each, seen_ids)
+
+            merged = popular + recent
+
+            return merged
+
+        except Exception as e:
+            self.logger.exception(f"댓글 조회 중 오류가 발생했습니다: {e}")
+            return []

--- a/app/briefing/exception.py
+++ b/app/briefing/exception.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+from app.exception import RecipeSummaryException
+
+
+class BriefingErrorCode(Enum):
+    BRIEFING_GENERATE_FAILED = ("BRIEFING_001", "브리핑 생성 중 오류가 발생했습니다.")
+    BRIEFING_NOT_ENOUGH_COMMENTS = ("BRIEFING_002", "댓글이 너무 적거나 유의미한 내용이 없습니다.")
+    
+    def __init__(self, code: str, message: str):
+        self._code = code
+        self._message = message
+
+    @property
+    def code(self) -> str:
+        return self._code
+
+    @property
+    def message(self) -> str:
+        return self._message
+
+class BriefingException(RecipeSummaryException):
+    def __init__(self, code: Enum):
+        super().__init__(code)
+        self.code = code

--- a/app/briefing/generator.py
+++ b/app/briefing/generator.py
@@ -1,0 +1,100 @@
+import json
+import logging
+from pathlib import Path
+from typing import List
+
+import boto3
+from botocore.config import Config
+
+from app.briefing.exception import BriefingErrorCode, BriefingException
+
+
+class BriefingGenerator:
+    def __init__(
+        self,
+        *,
+        model_id: str,
+        region: str,
+        inference_profile_arn: str,
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+        generate_user_prompt_path: Path,
+        briefing_tool_path: Path,
+    ):
+        self.logger = logging.getLogger(__name__)
+        self.model_id = model_id
+        self.region = region
+        self.inference_profile_arn = inference_profile_arn
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+
+        # ---- 프롬프트/툴 로드 ----
+        self.briefing_prompt = generate_user_prompt_path.read_text(encoding="utf-8")
+        self.briefing_tool = json.loads(briefing_tool_path.read_text(encoding="utf-8"))
+
+        self.client = boto3.client(
+            "bedrock-runtime",
+            config=Config(region_name=region, retries={"max_attempts": 3, "mode": "adaptive"})
+        )
+
+    def _converse_briefing(self, user_prompt: str) -> List[str]:
+        """
+        LLM 결과(브리핑 문장 리스트)를 반환.
+        - toolUse name="emit_briefing", input={"items": ["문장1", "문장2", ...]} 형태를 기대.
+        """
+        try:
+            model_identifier = self.inference_profile_arn or self.model_id
+        
+            resp = self.client.converse(
+                modelId=model_identifier,
+                messages=[{"role": "user", "content": [{"text": user_prompt}]}],
+                toolConfig={
+                    "tools": self.briefing_tool,
+                    "toolChoice": {"tool": {"name": "emit_briefing"}}
+                },
+                inferenceConfig={
+                    "maxTokens": self.max_tokens,
+                    "temperature": self.temperature
+                },
+            )
+            content = resp.get("output", {}).get("message", {}).get("content", [])
+
+            for item in content:
+                tu = item.get("toolUse")
+                if tu and tu.get("name") == "emit_briefing":
+                    obj = tu.get("input", {})
+                    items = obj.get("items", [])
+                    return [str(item) for item in items]
+
+        except Exception as e:
+            self.logger.error(f"브리핑 생성 중 오류가 발생했습니다: {e}")
+            raise BriefingException(BriefingErrorCode.BRIEFING_GENERATE_FAILED)
+
+    def generate_briefing_from_comments(self, comments: List[str]) -> List[str]:
+        """
+        댓글(List[str])을 입력받아 브리핑 문장 리스트를 반환.
+        - 레시피 관련 2~5문장
+        - 2개 미만이면 예외 발생
+        """
+        try:
+            comments_json = json.dumps(
+                [c for c in comments if isinstance(c, str) and c.strip()],
+                ensure_ascii=False
+            )
+            prompt = self.briefing_prompt.replace("{{ comments_json }}", comments_json)
+
+            result = self._converse_briefing(prompt)
+
+            # 최대 5개로 제한
+            if len(result) > 5:
+                result = result[:5]
+
+            # 2개 미만이면 예외 발생
+            if len(result) < 2:
+                raise BriefingException(BriefingErrorCode.BRIEFING_NOT_ENOUGH_COMMENTS)
+
+            return result
+
+        except Exception as e:
+            self.logger.error(f'브리핑 생성 중 오류가 발생했습니다: {e}')
+            raise BriefingException(BriefingErrorCode.BRIEFING_GENERATE_FAILED)

--- a/app/briefing/prompt/generate.md
+++ b/app/briefing/prompt/generate.md
@@ -1,0 +1,44 @@
+# [Prompt]
+
+The following is a JSON array of viewer comments from a YouTube recipe video. Based only on these comments, generate a recipe-related briefing.
+
+---
+
+## [Objectives]
+
+- Summarize only content directly related to the recipe: actual cooking experiences (difficulty/time/success–failure points), reviews of taste/flavor/texture, concrete opinions such as substitute ingredients, cooking tips, storage/reheating advice.
+- Must exclude: editing/creator compliments, ads/links, chit-chat/exclamations, unanswered questions, political/social/religious or otherwise irrelevant content.
+- **Repeated or similar content must be prioritized**. Merge similar experiences/claims into one representative sentence.
+- **Frequency-based summarization rule**:
+  1. Identify the recipe-related topics most frequently mentioned
+  2. Summarize each into one essential and generalizable sentence
+  3. If slots remain, add less frequent but useful concrete tips for improving the recipe
+- No speculation or invention. Use only information that actually appears in the comments.
+- The result must consist of **2–5 concise Korean declarative sentences (List[str])**.
+- Each sentence must be **at least 5 characters and at most 50 characters long**.
+- Each sentence must end with the **Korean “~해요” style (polite ending)**, and should sound natural.
+- If there are fewer than 2 valid recipe-related points, return an **empty array ([])**.
+
+---
+
+## [Output format]
+
+- toolUse: emit_briefing
+- input: {"items": ["Sentence1", "Sentence2", ...]}  
+  // Korean, 2–5 items. If fewer than 2, return an empty array.
+
+---
+
+## [Writing guide]
+
+- Reflect “what was most frequently mentioned” in the comments.  
+  (Example: “Many comments said it was too salty” → “간이 강하니 소금/간장 양을 줄이라는 피드백이 많아요.”)
+- Merge similar expressions, but if critical conditions (ingredients, ratios, time, tools, heat level, etc.) are repeatedly mentioned, include them.
+- Prioritize reproducible tips/conditions over vague impressions.
+- **All output must be written in Korean.**
+
+---
+
+## [Comments (JSON array)]
+
+{{ comments_json }}

--- a/app/briefing/prompt/tool.json
+++ b/app/briefing/prompt/tool.json
@@ -1,0 +1,28 @@
+[
+  {
+    "toolSpec": {
+      "name": "emit_briefing",
+      "description": "Summarize viewer comments about a recipe video into concise Korean briefing lines (2–5 items). Each item must be a complete Korean sentence between 5 and 50 characters. The items field must always be a JSON array, never a string.",
+      "inputSchema": {
+        "json": {
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "array",
+              "description": "Direct JSON array of Korean briefing lines. Example: {\"items\": [\"첫 번째 문장.\", \"두 번째 문장.\"]}. Never return as a quoted string.",
+              "items": {
+                "type": "string",
+                "minLength": 5,
+                "maxLength": 50
+              },
+              "minItems": 0,
+              "maxItems": 5
+            }
+          },
+          "required": ["items"],
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+]

--- a/app/briefing/router.py
+++ b/app/briefing/router.py
@@ -1,0 +1,16 @@
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from app.briefing.schema import BriefingRequest, BriefingResponse
+from app.briefing.service import BriefingService
+from app.container import Container
+
+router = APIRouter()
+
+@router.post("/briefings", response_model=BriefingResponse)
+@inject
+async def get_briefing(
+    request: BriefingRequest,
+    briefing_service: BriefingService = Depends(Provide[Container.briefing_service])
+):
+    return BriefingResponse(briefings=await briefing_service.get(request.video_id))

--- a/app/briefing/schema.py
+++ b/app/briefing/schema.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class BriefingRequest(BaseModel):
+    video_id: str = Field(..., description="영상 ID")
+
+
+class BriefingResponse(BaseModel):
+    briefings: List[str] = Field(..., description="브리핑 내용")

--- a/app/briefing/service.py
+++ b/app/briefing/service.py
@@ -1,0 +1,22 @@
+import asyncio
+import logging
+
+from app.briefing.client import BriefingClient
+from app.briefing.generator import BriefingGenerator
+from app.briefing.schema import BriefingResponse
+
+
+class BriefingService:
+    def __init__(self, client: BriefingClient, generator: BriefingGenerator):
+        self.logger = logging.getLogger(__name__)
+        self.client = client
+        self.generator = generator
+
+    async def get(self, video_id: str) -> BriefingResponse:
+        comments = await asyncio.to_thread(
+            self.client.get_video_comments, video_id
+        )
+
+        return await asyncio.to_thread(
+            self.generator.generate_briefing_from_comments, comments
+        )

--- a/app/container.py
+++ b/app/container.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from dependency_injector import containers, providers
 from openai import AsyncOpenAI
 
+from app.briefing.client import BriefingClient
+from app.briefing.generator import BriefingGenerator
+from app.briefing.service import BriefingService
 from app.caption.client import CaptionClient
 from app.caption.recipe_validator import CaptionRecipeValidator
 from app.caption.service import CaptionService
@@ -26,6 +29,7 @@ class Container(containers.DeclarativeContainer):
             "app.caption",
             "app.meta",
             "app.step",
+            "app.briefing",
         ]
     )
 
@@ -96,6 +100,27 @@ class Container(containers.DeclarativeContainer):
     step_service = providers.Factory(
         StepService,
         generator=step_generator,
+    )
+
+    # Briefing
+    briefing_client = providers.Singleton(
+        BriefingClient,
+        api_key=config.google.api_key,
+        timeout=20.0,
+    )
+    briefing_generator = providers.Singleton(
+        BriefingGenerator,
+        model_id=config.bedrock.model_id,
+        region=config.aws.region,
+        inference_profile_arn=config.bedrock.profile,
+
+        briefing_tool_path=Path("app/briefing/prompt/tool.json"),
+        generate_user_prompt_path=Path("app/briefing/prompt/generate.md"),
+    )
+    briefing_service = providers.Factory(
+        BriefingService,
+        client=briefing_client,
+        generator=briefing_generator,
     )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from app.briefing.router import router as briefing_router
 from app.caption.router import router as caption_router
 from app.container import container
 from app.exception import BusinessException
@@ -43,3 +44,4 @@ async def business_exception_handler(request: Request, exc: BusinessException):
 app.include_router(caption_router)
 app.include_router(meta_router)
 app.include_router(step_router)
+app.include_router(briefing_router)


### PR DESCRIPTION
[TORY-193 feat(briefing): 유튜브 댓글 기반 브리핑 생성 기능 추가](https://github.com/SWMChefTory/ai-recipe-summary/commit/6524161b3bc5f0e5f719a75f2e9fab7e861b0c8e) 

- Bedrock Claude Sonnet 4를 활용한 BriefingGenerator 구현
- 레시피 관련 브리핑 프롬프트 및 tool 스키마 추가 (한국어, ~해요체, 2~5개 문장, 문장 길이 5~50자)
- 반복/유사 피드백을 우선적으로 포함하고 병합하도록 처리
- 유효한 댓글이 부족하거나 없을 경우 빈 리스트 반환 처리

[TORY-193 feature(briefing): FastAPI 엔드포인트 /briefings 추가 및 DI 컨테이너 연동](https://github.com/SWMChefTory/ai-recipe-summary/commit/e7c4a21d5de220db01caecc9774ff5b825e68c81)